### PR TITLE
Split into variants for "play" and "fdroid"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,19 @@ android {
         disable "ResourceType"
         disable 'GoogleAppIndexingWarning'
     }
+
+    flavorDimensions "distribution"
+
+    productFlavors {
+        play {
+            dimension "distribution"
+        }
+
+        fdroid {
+            dimension "distribution"
+            versionNameSuffix "-fdroid"
+        }
+    }
 }
 
 dependencies {
@@ -32,9 +45,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.emoji:emoji-appcompat:1.1.0'
     implementation 'androidx.preference:preference-ktx:1.1.1'
-    implementation 'com.google.android.gms:play-services-ads-lite:19.7.0'
     implementation 'com.mobeta.android.dslv:library:0.9.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    playImplementation 'com.google.android.gms:play-services-ads-lite:19.7.0'
 }
 repositories {
     mavenCentral()

--- a/app/src/fdroid/java/jp/ddo/hotmist/unicodepad/AdCompatImpl.kt
+++ b/app/src/fdroid/java/jp/ddo/hotmist/unicodepad/AdCompatImpl.kt
@@ -1,0 +1,10 @@
+package jp.ddo.hotmist.unicodepad
+
+import android.app.Activity
+import android.content.SharedPreferences
+
+internal class AdCompatImpl : AdCompat {
+    override val showAdSettings = false
+    override fun renderAdToContainer(activity: Activity, pref: SharedPreferences) {
+    }
+}

--- a/app/src/fdroid/res/layout/ad_container.xml
+++ b/app/src/fdroid/res/layout/ad_container.xml
@@ -1,0 +1,1 @@
+<merge xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/app/src/main/java/jp/ddo/hotmist/unicodepad/AdCompat.kt
+++ b/app/src/main/java/jp/ddo/hotmist/unicodepad/AdCompat.kt
@@ -1,0 +1,9 @@
+package jp.ddo.hotmist.unicodepad
+
+import android.app.Activity
+import android.content.SharedPreferences
+
+internal interface AdCompat {
+  fun renderAdToContainer(activity: Activity, pref: SharedPreferences)
+  val showAdSettings: Boolean
+}

--- a/app/src/main/java/jp/ddo/hotmist/unicodepad/SettingActivity.kt
+++ b/app/src/main/java/jp/ddo/hotmist/unicodepad/SettingActivity.kt
@@ -26,6 +26,7 @@ import android.text.ClipboardManager
 import android.widget.Toast
 
 class SettingActivity : PreferenceActivity(), OnPreferenceChangeListener {
+    private val adCompat: AdCompat = AdCompatImpl()
     override fun onCreate(savedInstanceState: Bundle?) {
         val pref = PreferenceManager.getDefaultSharedPreferences(this)
         setTheme(THEME[(pref.getString("theme", null)?.toIntOrNull() ?: 2131492983) - 2131492983])
@@ -74,6 +75,11 @@ class SettingActivity : PreferenceActivity(), OnPreferenceChangeListener {
         findPreference("legal_uni").also {
             it.setOnPreferenceClickListener {
                 openPage("https://unicode.org/")
+            }
+        }
+        if (!adCompat.showAdSettings) {
+            findPreference("no-ad").also {
+                it.parent?.removePreference(it);
             }
         }
         setResult(RESULT_OK)

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -164,11 +164,6 @@
 
 	</jp.ddo.hotmist.unicodepad.LockableScrollView>
 
-	<LinearLayout
-		android:id="@+id/adContainer"
-		android:layout_width="match_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical">
-	</LinearLayout>
+	<include layout="@layout/ad_container" />
 
 </LinearLayout>

--- a/app/src/play/java/jp/ddo/hotmist/unicodepad/AdCompatImpl.kt
+++ b/app/src/play/java/jp/ddo/hotmist/unicodepad/AdCompatImpl.kt
@@ -1,0 +1,43 @@
+package jp.ddo.hotmist.unicodepad
+
+import android.util.DisplayMetrics
+import android.view.View
+import android.widget.LinearLayout
+
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.MobileAds
+
+import android.app.Activity
+import android.content.SharedPreferences
+import android.util.Log
+
+internal class AdCompatImpl : AdCompat {
+    override val showAdSettings = true
+    override fun renderAdToContainer(activity: Activity, pref: SharedPreferences) {
+        val adContainer = activity.findViewById<LinearLayout>(R.id.adContainer)
+        if (adContainer != null) {
+            if (!pref.getBoolean("no-ad", false)) {
+                if (adContainer.childCount == 0) {
+                    try {
+                        MobileAds.initialize(activity) { }
+                        AdView(activity).also {
+                            val outMetrics = DisplayMetrics()
+                            activity.windowManager.defaultDisplay.getMetrics(outMetrics)
+                            it.adSize = AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(activity, (outMetrics.widthPixels / outMetrics.density).toInt())
+                            it.adUnitId = "ca-app-pub-8779692709020298/6882844952"
+                            (activity.findViewById<View>(R.id.adContainer) as LinearLayout).addView(it)
+                            val adRequest = AdRequest.Builder().build()
+                            it.loadAd(adRequest)
+                        }
+                    } catch (e: NullPointerException) {}
+                }
+            } else {
+                if (adContainer.childCount > 0) {
+                    adContainer.removeAllViews()
+                }
+            }
+        }
+    }
+}

--- a/app/src/play/res/layout/ad_container.xml
+++ b/app/src/play/res/layout/ad_container.xml
@@ -1,0 +1,8 @@
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+
+        android:id="@+id/adContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+</LinearLayout>


### PR DESCRIPTION
play: Works exactly as before.
fdroid: does not contain any ads/ad libraries making the app compatible
  with FDroid again.

Both variants share the same application ID so users of both platforms
will get seamless upgrades.

Fixes #48.

I couldn't actually make the ads show up in my test builds. (Also not with the original version).
So this would need some validation.